### PR TITLE
Manifest.csv duplicating fix

### DIFF
--- a/cchdo/snapshotter/__main__.py
+++ b/cchdo/snapshotter/__main__.py
@@ -134,6 +134,10 @@ async def get_and_write_to_temp(session, path: Path, uri, fhash, progress, total
 
     progress.update(total, advance=1)
 
+def initialize_manifest(snapshot: Path):
+    with (snapshot / "_manifest.csv").open("w", newline="") as manifest:
+        writer = csv.writer(manifest, lineterminator="\n")
+        writer.writerow(("file", "size", "sha256"))
 
 def write_manifest_line(snapshot: Path, line):
     with (snapshot / "_manifest.csv").open("+a") as manifest:
@@ -162,7 +166,7 @@ async def main():
 
     snapshot.mkdir(exist_ok=True)
 
-    write_manifest_line(snapshot, "file,size,sha256")
+    initialize_manifest(snapshot)
 
     with ZipFile(
         snapshot / "cruise_history.zip", "w", compression=ZIP_DEFLATED, compresslevel=9

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from cchdo.snapshotter.__main__ import initialize_manifest, write_manifest_line
+
+
+class ManifestTests(unittest.TestCase):
+    def test_manifest_reset_on_restart(self):
+        with TemporaryDirectory() as directory:
+            snapshot = Path(directory)
+
+            initialize_manifest(snapshot)
+            write_manifest_line(snapshot, "first.zip,10,hash1")
+            write_manifest_line(snapshot, "second.zip,20,hash2")
+
+            # Simulate restarting on the same day.
+            initialize_manifest(snapshot)
+            write_manifest_line(snapshot, "third.zip,30,hash3")
+
+            content = (snapshot / "_manifest.csv").read_text().splitlines()
+
+            self.assertEqual(
+                content,
+                ["file,size,sha256", "third.zip,30,hash3"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ho Jung pointed out that "the script used to write to _manifest.csv seems to be duplicating some lines as well as the header." This is likely from re-running the script the same day (e.g. if AWS instance freezes).

- Initialize _manifest.csv in write mode before generating snapshot files,
rather than appending another header to an existing manifest.
- This prevents duplicate headers and checksum rows when the snapshotter is
restarted on the same day and reuses the existing dated output directory.
- Keep incremental manifest row writes unchanged
- included a regression test for the bug, which passed as of today (can omit if not needed)